### PR TITLE
jpa buddy 플러그인의 설정 파일을 무시하도록 .gitignore 수정

### DIFF
--- a/part2/fastcampus-project-board/.gitignore
+++ b/part2/fastcampus-project-board/.gitignore
@@ -8,6 +8,9 @@ build/
 ### Querydsl
 /src/main/generated
 
+### JPA Buddy
+.jpb/
+
 ### STS ###
 .apt_generated
 .classpath


### PR DESCRIPTION
Intellij plugin 중 jpa 작업을 편하게 해주는 `jpa buddy` 플러그인으로 인해 자동 생성되는 설정 파일이 프로젝트에 포함되지 않도록 파일 무시 규칙을 추가함.